### PR TITLE
Update system rubygems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,6 @@ ENV PATH /usr/local/rbenv/bin:/usr/local/rbenv/shims:$PATH
 RUN eval "$(rbenv init -)"; rbenv install 2.3.0 \
 &&  eval "$(rbenv init -)"; rbenv global 2.3.0
 
+RUN eval "$(rbenv init -)"; gem update --system
 RUN eval "$(rbenv init -)"; gem install bundler
 


### PR DESCRIPTION
Ruby 2.3系 + rubygems 2.6.2で `bundle exec 〜` すると下記のようなエラーになる

``` sh
+ bundle exec cap staging deploy
bundler: failed to load command: cap (/builds/other/app/vendor/bundle/ruby/2.3.0/bin/cap)
NoMethodError: undefined method `activate_bin_path' for Gem:Module
  /builds/other/app/vendor/bundle/ruby/2.3.0/bin/cap:22:in `<top (required)>'

ERROR: Build failed with: exit code 1
```

基本的にはビルド時点の最新のrubygemsを使うでいいと思う（社内のレシピも同じことしてる）
# 関連リンク
- http://stackoverflow.com/questions/37103995/rails-command-giving-error
